### PR TITLE
Update static and media settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist/
 # Django
 *.log
 staticfiles/
+media/
 
 # React
 frontend/build/

--- a/backend/abhijitongit_be/settings.py
+++ b/backend/abhijitongit_be/settings.py
@@ -122,6 +122,9 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/5.2/howto/static-files/
 
 STATIC_URL = 'static/'
+STATIC_ROOT = BASE_DIR / 'staticfiles'
+MEDIA_URL = 'media/'
+MEDIA_ROOT = BASE_DIR / 'media'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field


### PR DESCRIPTION
## Summary
- configure STATIC_ROOT and MEDIA_ROOT
- ignore media/ directory in .gitignore

## Testing
- `python backend/manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_687aadc7b10c832abd86308b175022c5