### PR TITLE
Correct spacer background image path

### DIFF
--- a/backend/core/templates/core/index.html
+++ b/backend/core/templates/core/index.html
@@ -52,7 +52,7 @@
     {% block content %}{% endblock %}
 
     <!-- Spacer Background Image -->
-    <div class="py-5 bg-image-full" style="background-image: url('{% static 'core/images/spacer-bg.gif' %}')">
+    <div class="py-5 bg-image-full" style="background-image: url('{% static 'core/images/space-bg.gif' %}')">
         <div style="height: 20rem"></div>
     </div>
 


### PR DESCRIPTION
## Summary
- fix the spacer background image path in `index.html`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687ab06193c8832aa37e0c79d620786f