### PR TITLE
Provide current year to all templates

### DIFF
--- a/backend/core/templates/core/base.html
+++ b/backend/core/templates/core/base.html
@@ -59,7 +59,7 @@
     <!-- Footer -->
     <footer class="py-5 bg-dark">
         <div class="container">
-            <p class="m-0 text-center text-white">&copy; {{ now|date:"Y" }} My Portfolio</p>
+            <p class="m-0 text-center text-white">&copy; {% now "Y" %} My Portfolio</p>
         </div>
     </footer>
 

--- a/backend/core/templates/core/index.html
+++ b/backend/core/templates/core/index.html
@@ -59,7 +59,7 @@
     <!-- Footer -->
     <footer class="py-5 bg-dark">
         <div class="container">
-            <p class="m-0 text-center text-white">&copy; {{ now|date:"Y" }} My Portfolio</p>
+            <p class="m-0 text-center text-white">&copy; {% now "Y" %} My Portfolio</p>
         </div>
     </footer>
 

--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -4,12 +4,11 @@ from .models import Project, Skill, Experience, ContactMessage
 from .serializers import ProjectSerializer, SkillSerializer, ExperienceSerializer, ContactMessageSerializer
 from django.core.mail import send_mail
 from django.conf import settings
-from django.utils.timezone import now
 
 
 # HTML PAGES
 def home_view(request):
-    return render(request, 'core/home.html', {'now': now()})
+    return render(request, 'core/home.html')
 
 def projects_view(request):
     return render(request, 'core/projects.html')


### PR DESCRIPTION
## Summary
- show the current year directly in templates
- drop unused `now()` context from `home_view`

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687ab067fbcc832a801a57b25c4d7c67